### PR TITLE
feat: finalize aliasing

### DIFF
--- a/ALIASING_INTEGRATION_SUMMARY.md
+++ b/ALIASING_INTEGRATION_SUMMARY.md
@@ -1,0 +1,85 @@
+# Aliasing Implementation Integration Summary
+
+## Overview
+
+We reviewed an existing PR that implemented aliasing support using a reflection-based approach. After analysis, we integrated the valuable parts while maintaining our cleaner implementation using `yamlops.GetRelationTargetName()`.
+
+## What We Integrated from the PR
+
+### 1. **Validation Function** ✅
+Added `validateAliasedRelations()` to ensure aliased target models exist:
+```go
+func validateAliasedRelations(r *registry.Registry, model yaml.Model) error {
+    for relationName, relation := range model.Related {
+        targetModelName := yamlops.GetRelationTargetName(relationName, relation.Aliased)
+        
+        // Only validate if the target is different (i.e., aliased)
+        if targetModelName != relationName {
+            _, err := r.GetModel(targetModelName)
+            if err != nil {
+                return fmt.Errorf("aliased target model '%s' for relation '%s' in model '%s' not found", 
+                    targetModelName, relationName, model.Name)
+            }
+        }
+    }
+    return nil
+}
+```
+
+**Benefit**: Early validation prevents runtime errors when aliased targets don't exist.
+
+### 2. **Test for Missing Targets** ✅
+Added `TestMorpheModelToPSQLTables_Related_Aliased_MissingTarget` to verify validation works correctly.
+
+**Benefit**: Ensures our validation catches configuration errors.
+
+## What We Did NOT Integrate
+
+### 1. **Reflection-Based Approach** ❌
+The PR used reflection to detect the `Aliased` field:
+```go
+// Their approach
+relationValue := reflect.ValueOf(relation)
+aliasedField := relationValue.FieldByName("Aliased")
+```
+
+**Why not**: We use `yamlops.GetRelationTargetName()` which is the official API in morphe-go.
+
+### 2. **Separate aliasing.go File** ❌
+The PR created a new file with helper functions.
+
+**Why not**: Our implementation is simpler and uses existing functions directly.
+
+### 3. **Wrapper Functions** ❌
+Functions like `GetForeignKeyColumnNameWithAlias()` that wrap existing functions.
+
+**Why not**: Unnecessary indirection - we can call existing functions with resolved names.
+
+## Key Differences in Our Approach
+
+### 1. **Direct API Usage**
+```go
+// Our approach (cleaner)
+targetModelName := yamlops.GetRelationTargetName(relationName, relation.Aliased)
+
+// PR approach (reflection)
+targetModelName := GetTargetModelNameFromRelation(relationName, relation)
+```
+
+### 2. **Inline Implementation**
+We integrated aliasing directly into the existing functions rather than creating wrapper functions.
+
+### 3. **Consistent with morphe-go**
+Our implementation uses the same function (`yamlops.GetRelationTargetName`) that morphe-go uses internally.
+
+## Final Implementation Status
+
+Our implementation now includes:
+- ✅ Full aliasing support in model compilation
+- ✅ Full aliasing support in entity compilation  
+- ✅ Validation for missing aliased targets
+- ✅ Comprehensive test coverage
+- ✅ Backward compatibility
+- ✅ Documentation for morphe-go requirements
+
+The implementation is complete and ready for use once the `Aliased` field is added to morphe-go's ModelRelation struct.

--- a/MORPHE-GO.md
+++ b/MORPHE-GO.md
@@ -1,0 +1,240 @@
+# Morphe-Go Entity Aliasing Validation Implementation Guide
+
+## Overview
+
+This document provides implementation instructions for adding entity aliasing validation support to morphe-go. The plugin-morphe-psql-types has already implemented aliasing support for SQL generation, but morphe-go's entity validation needs to be updated to understand aliased relationships in entity field paths.
+
+## Problem Statement
+
+### Current Behavior
+When an entity field references a path through an aliased relationship (e.g., `Person.WorkContact.Email`), the entity validation fails with an error like:
+```
+morphe entity PersonProfile field workEmail references unknown model: WorkContact in path Person.WorkContact.Email
+```
+
+This happens because the validation tries to find a model named "WorkContact" but doesn't know it's an alias for "Contact".
+
+### Root Cause
+The entity validation in morphe-go occurs before the compilation phase, so it doesn't have access to the alias resolution logic that's already implemented in plugin-morphe-psql-types.
+
+## Required Implementation
+
+### 1. Core Changes to Entity Validation
+
+#### 1.1 Update Field Path Validation Logic
+
+The entity field path validation needs to resolve aliases when traversing relationships. Here's the algorithm:
+
+```go
+// Pseudo-code for the updated validation logic
+func validateEntityFieldPath(path string, models map[string]Model) error {
+    segments := strings.Split(path, ".")
+    if len(segments) < 2 {
+        return fmt.Errorf("invalid field path: %s", path)
+    }
+    
+    // Start with the root model
+    currentModelName := segments[0]
+    currentModel, exists := models[currentModelName]
+    if !exists {
+        return fmt.Errorf("model %s not found in field path %s", currentModelName, path)
+    }
+    
+    // Traverse through relationships
+    for i := 1; i < len(segments)-1; i++ {
+        relationName := segments[i]
+        relation, exists := currentModel.Related[relationName]
+        if !exists {
+            return fmt.Errorf("relationship %s not found in model %s", 
+                relationName, currentModel.Name)
+        }
+        
+        // CRITICAL: Resolve the aliased target using yamlops
+        targetModelName := yamlops.GetRelationTargetName(relationName, relation.Aliased)
+        
+        // Load the target model
+        nextModel, exists := models[targetModelName]
+        if !exists {
+            return fmt.Errorf("aliased target model %s not found for relationship %s in model %s", 
+                targetModelName, relationName, currentModel.Name)
+        }
+        
+        currentModel = nextModel
+        currentModelName = targetModelName
+    }
+    
+    // Validate the final field exists
+    fieldName := segments[len(segments)-1]
+    if _, exists := currentModel.Fields[fieldName]; !exists {
+        return fmt.Errorf("field %s not found in model %s (reached via path %s)", 
+            fieldName, currentModelName, path)
+    }
+    
+    return nil
+}
+```
+
+#### 1.2 Integration Point
+
+This logic should be integrated into the `Entity.Validate()` method, specifically in the section that validates entity field types that contain dots (field paths).
+
+### 2. Special Cases to Handle
+
+#### 2.1 Polymorphic Relationships
+
+Polymorphic relationships with aliases need special handling:
+
+```go
+// For polymorphic relationships, check if the alias contains a dot
+// Example: "Comment.Commentable" where Commentable is the inverse
+if yamlops.IsRelationPoly(relation.Type) && strings.Contains(relation.Aliased, ".") {
+    // Extract just the model name part
+    parts := strings.Split(relation.Aliased, ".")
+    targetModelName = parts[0]
+    // Note: The inverse relationship validation should happen separately
+}
+```
+
+#### 2.2 Direct Relationship References
+
+The current validation correctly prevents direct references to relationships in entity fields. This should continue to work:
+
+```go
+// This should still be invalid:
+fields:
+  myRelation:
+    type: Model.RelationshipName  # Invalid - can't reference relationship directly
+```
+
+### 3. Error Message Guidelines
+
+Error messages should be clear and helpful:
+
+```go
+// Good error messages that distinguish between different failure modes:
+
+// When relationship doesn't exist
+"relationship WorkContact not found in model Person"
+
+// When aliased target doesn't exist
+"aliased target model Contact not found for relationship WorkContact in model Person"
+
+// When field doesn't exist in the resolved model
+"field Email not found in model Contact (reached via path Person.WorkContact.Email)"
+
+// For polymorphic relationships
+"cannot traverse through polymorphic relationship Commentable in path Post.Commentable.Text"
+```
+
+### 4. Implementation Checklist
+
+- [ ] Locate the `Entity.Validate()` method in morphe-go
+- [ ] Find the section that validates entity field types containing dots
+- [ ] Import or ensure access to `yamlops.GetRelationTargetName()`
+- [ ] Implement the alias resolution logic in the field path traversal
+- [ ] Update error messages to be more informative about aliasing
+- [ ] Add unit tests for aliased field paths (see Testing section)
+- [ ] Ensure backward compatibility - non-aliased paths must continue to work
+
+### 5. Testing
+
+#### 5.1 Basic Aliasing Test Case
+
+```yaml
+# Models
+---
+name: Person
+fields:
+  ID:
+    type: AutoIncrement
+related:
+  WorkContact:
+    type: ForOne
+    aliased: Contact
+  PersonalContact:
+    type: ForOne  
+    aliased: Contact
+---
+name: Contact
+fields:
+  ID:
+    type: AutoIncrement
+  Email:
+    type: String
+  Phone:
+    type: String
+
+# Entity - should validate successfully
+---
+name: PersonProfile
+fields:
+  id:
+    type: Person.ID
+  workEmail:
+    type: Person.WorkContact.Email      # Should resolve to Contact.Email
+  personalPhone:
+    type: Person.PersonalContact.Phone  # Should resolve to Contact.Phone
+```
+
+#### 5.2 Error Cases to Test
+
+```yaml
+# Test 1: Aliased target doesn't exist
+related:
+  BadAlias:
+    type: ForOne
+    aliased: NonExistentModel  # Should fail validation
+
+# Test 2: Field doesn't exist in aliased target
+fields:
+  badField:
+    type: Person.WorkContact.NonExistentField  # Should fail
+
+# Test 3: Attempting to traverse through polymorphic (should fail appropriately)
+fields:
+  invalid:
+    type: Post.Comments.Author  # Where Comments is polymorphic
+```
+
+#### 5.3 Complex Traversal Test
+
+```yaml
+# Test multi-hop traversal through aliases
+name: Company
+related:
+  CEO:
+    type: ForOne
+    aliased: Person
+
+# Should be able to traverse: Company.CEO.WorkContact.Email
+```
+
+### 6. Dependencies
+
+- The implementation requires access to `yamlops.GetRelationTargetName()` function
+- No changes needed to the YAML structure or schema
+- Must maintain backward compatibility with existing entity definitions
+
+### 7. Expected Outcome
+
+After implementing these changes:
+
+1. Entities can reference fields through aliased relationships
+2. Validation errors clearly indicate whether issues are with relationships, aliases, or fields
+3. All existing entity validations continue to work
+4. The validation phase and compilation phase use the same alias resolution logic
+
+### 8. Additional Notes
+
+- The plugin-morphe-psql-types already has working aliasing implementation for the compilation phase
+- The key is to use the same `yamlops.GetRelationTargetName()` function for consistency
+- Entity validation happens in `entity.Validate()` before compilation, so it needs its own alias resolution
+- The validation should only resolve aliases for traversal - it should not change how the compiled SQL is generated (that's already handled correctly)
+
+## Questions or Issues?
+
+If you encounter any issues or need clarification:
+
+1. Check the existing aliasing implementation in plugin-morphe-psql-types (pkg/compile/compile_models.go and compile_entities.go)
+2. Look for uses of `yamlops.GetRelationTargetName()` for examples
+3. The test files in plugin-morphe-psql-types show expected behavior for aliased relationships

--- a/aliasing.md
+++ b/aliasing.md
@@ -1,0 +1,381 @@
+# Relationship Aliasing Implementation Plan
+
+## 0. Rules & Principles
+
+- **Consistency**: Follow existing codebase patterns (naming conventions, error handling, test structure)
+- **Minimal scope**: Each task focuses on one specific feature implementation
+- **Minimal redundancy**: New code attempts to leverage existing code when there is domain- / usage-level overlap to mitigate code fragmentation and manual update friction
+- **Cohesion <> Coupling**: Apply minimal coupling and maximum cohesion software principles
+- **Idiomatic Go**: Clean, readable code following Go best practices
+- **Clean Code**: Clean code practices like "no deep nesting", early return, SRP, ...
+- **TDD approach**: Red-Green-Refactor cycle with 1-2 refactor loops per task, and tests for realistic edge cases (including error cases)
+- **Testing style**: Use testify assertions; one test per case for simple functions (boolean/regex), arrange-act-assert blocks for complex tests; minimize comments
+- **Human review**: Mandatory pause after each green run for testing and feedback
+- **Backward compatibility**: All changes must not break existing functionality
+- **Database integrity**: All aliased relationships must maintain referential integrity via proper constraint naming
+- **Planning**: After task completion, reevaluate upcoming tasks and revisit adding new / updating existing
+
+## 1. Codebase ⇄ Spec Gap Analysis
+
+### Current State
+- **Supported Relations**: `ForOne`, `ForMany`, `HasOne`, `HasMany`, `ForOnePoly`, `ForManyPoly`, `HasOnePoly`, `HasManyPoly`
+- **Relationship Names**: Direct mapping between relationship name and target model name
+- **SQL Generation**: Foreign keys, junction tables, constraints use relationship names directly
+- **Entity References**: Field paths reference relationships by their direct names
+
+### Missing Components for Aliasing
+
+#### Core Logic Modules
+- `morphe-go/pkg/yaml/model_relation.go`: ✅ **DONE** - Added `aliased` field in ModelRelation structure
+- `morphe-go/pkg/yaml/entity_relation.go`: ✅ **DONE** - Added `aliased` field in EntityRelation structure
+- `morphe-go/pkg/yamlops/relation.go`: ✅ **DONE** - Added aliasing detection functions (IsRelationAliased, GetRelationTargetName)
+- `morphe-go/pkg/yaml/normalize.go`: ✅ **DONE** - Added whitespace normalization for aliased fields
+- `pkg/compile/compile_models.go`: ⚠️ **PENDING** - Multiple functions need updates:
+  - `getColumnsForModelRelations` (lines 207-279): Uses relatedModelName directly
+  - `getForeignKeysForModelRelations` (lines 280-333): Uses relatedModelName directly  
+  - `getTablesForModelManyRelations` (lines 390-528): Uses relatedModelName for junction tables
+- `pkg/compile/compile_entities.go`: ⚠️ **PENDING** - Entity traversal issues:
+  - `traverseRelationshipChain` (line 198): Uses relationName as modelName
+  - `setupJoinsForRegularRelationships` (lines 302-314): Uses relationship name for joins
+  - `addJoinClause` (lines 317-381): Needs correct target model resolution
+
+#### Database Schema Components
+- **ForOne Aliasing**: Missing aliased foreign key column generation (`{alias_name}_id`)
+- **ForMany Aliasing**: Missing aliased junction table creation (`{source}_{alias_name}`)
+- **HasOne/HasMany Aliasing**: No validation for aliased inverse relationships
+- **Polymorphic Aliasing**: Missing aliased polymorphic column generation (`{alias_name}_type`, `{alias_name}_id`)
+- **Polymorphic Inverse Aliasing**: Missing validation for `HasOnePoly`/`HasManyPoly` with `aliased` + `through` pattern
+- **Constraint Naming**: No aliasing support in foreign key and unique constraint names
+
+#### Validation Components
+- **Aliased Target Validation**: ✅ **DONE** - Basic validation that `aliased` property references valid models/entities
+- **Polymorphic Inverse Validation**: ✅ **DONE** - Complex validation for `HasOnePoly`/`HasManyPoly` with `through` + `aliased` pattern
+- **Whitespace Normalization**: ✅ **DONE** - Aliased fields are normalized to trim whitespace
+- **Duplicate Alias Detection**: ⚠️ **PENDING** - No prevention of multiple relationships with same alias to same target
+- **Circular Alias Detection**: ⚠️ **PENDING** - No prevention of circular aliasing references
+- **Polymorphic Alias Validation**: ✅ **DONE** - Validates polymorphic relationships can use aliasing with `for` property
+
+#### Test Infrastructure
+- ✅ **DONE** - Comprehensive test coverage for basic aliasing (31 passing tests)
+- **PENDING** - Test models with polymorphic inverse aliased relationships
+- **PENDING** - Expected SQL output for aliased tables and constraints
+- Missing validation tests for complex polymorphic aliasing configurations
+- No entity field path tests with aliased relationships
+
+### Impacted Files
+```
+# External Dependencies (morphe-go repo) - ✅ COMPLETED
+morphe-go/pkg/yaml/model_relation.go     - ✅ Added 'aliased' field to ModelRelation
+morphe-go/pkg/yaml/entity_relation.go    - ✅ Added 'aliased' field to EntityRelation  
+morphe-go/pkg/yamlops/relation.go        - ✅ Aliasing detection functions
+morphe-go/pkg/yamlops/relation_test.go   - ✅ Tests for aliasing detection
+morphe-go/pkg/yaml/model.go              - ✅ Basic aliasing validation logic
+morphe-go/pkg/yaml/entity.go             - ✅ Basic aliased relationship validation
+
+# This Repository (plugin-morphe-psql-types)
+pkg/compile/compile_models.go            - Core aliasing compilation logic
+pkg/compile/compile_models_test.go       - Test coverage for aliased relationships
+pkg/compile/compile_entities.go          - Aliased field path resolution
+pkg/compile/compile_entities_test.go     - Entity aliasing test coverage
+pkg/compile/naming.go                    - Aliased table/column/constraint naming
+testdata/registry/                       - Aliased relationship examples
+testdata/ground-truth/                   - Expected aliased SQL output
+```
+
+## 2. Implementation Plan
+
+**Statuses:**
+
+- Ready: Ready to implement (in theory), practical prerequisites not checked
+- In progress: Implementing
+- Review: Ready for review by human
+- Done: Successfully implemented & reviewed by human
+
+### Task 1: Complete morphe-go Aliasing Support
+**Status**: ✅ **Done**
+**Scope**: BATCHED cross-repo changes - all morphe-go modifications for aliasing
+**Cross-Repo Dependency**: Single comprehensive morphe-go update + one dependency sync
+**Sub-tasks**:
+- **1.1** ✅ Add `aliased` field to ModelRelation and EntityRelation structures
+- **1.2** ✅ Implement aliasing detection functions in yamlops (`IsRelationAliased`, `GetRelationTargetName`)
+- **1.3** ✅ Add aliasing validation to Model and Entity validation logic
+- **1.4** ✅ Update deep clone methods for new aliased field
+- **1.5** ✅ Comprehensive morphe-go aliasing testing (31 passing tests)
+
+**Acceptance Criteria**: ✅ All completed
+- ✅ `aliased` field properly added to relation structures with YAML marshaling
+- ✅ Aliasing detection functions work correctly for all relationship types
+- ✅ Validation ensures aliased targets exist in registry
+- ✅ All existing tests continue to pass + new aliasing tests added
+
+### Task 2: ForOne/HasOne Aliasing Support
+**Status**: Ready
+**Scope**: Generate aliased foreign key columns and constraints for direct relationships
+**Implementation Details**:
+- **Files to modify**: 
+  - `compile_models.go`: `getColumnsForModelRelations` (line 238), `getForeignKeysForModelRelations` (line 292)
+  - Pattern: `targetModelName := yamlops.GetRelationTargetName(relatedModelName, modelRelation.Aliased)`
+**Acceptance Criteria**:
+- Uses relationship name for column naming (backward compatibility): `{relation_name}_id`
+- Foreign key constraints reference correct aliased target table
+- HasOne inverse relationships validate through aliased ForOne relationships
+- Proper constraint naming maintains relationship name (not aliased target)
+
+### Task 3: ForMany/HasMany Aliasing Support  
+**Status**: Ready
+**Scope**: Generate aliased junction tables and constraints for many-to-many relationships
+**Implementation Details**:
+- **Files to modify**:
+  - `compile_models.go`: `getTablesForModelManyRelations` (lines 408-528)
+  - Pattern: Use GetRelationTargetName for model lookups, maintain relationship name for table/column naming
+**Acceptance Criteria**:
+- Junction tables use relationship name: `{source_table}_{relation_name}` (backward compatibility)
+- Junction table columns use relationship name: `{relation_name}_id`
+- Foreign key constraints reference correct aliased target tables
+- HasMany inverse relationships validate through aliased ForMany relationships
+
+### Task 4: Polymorphic Aliasing Support
+**Status**: Ready
+**Scope**: Support aliasing for polymorphic relationships (ForOnePoly, ForManyPoly, Has*Poly)
+**Acceptance Criteria**:
+- ForOnePoly generates `{alias_name}_type` and `{alias_name}_id` columns
+- ForManyPoly junction tables use aliased naming (`{source_table}_{alias_name}`)
+- HasOnePoly/HasManyPoly validate through aliased polymorphic relationships
+- **Advanced**: Polymorphic inverse aliasing (`HasOnePoly` with `through` + `aliased`)
+- Polymorphic constraints and indexes use aliased names
+
+### Task 5: Entity-Level Aliasing Support
+**Status**: Ready
+**Scope**: Support referencing aliased model relationships in entities + entity-level aliasing
+**Implementation Details**:
+- **Files to modify**:
+  - `compile_entities.go`: `traverseRelationshipChain` (line 198), `setupJoinsForRegularRelationships`, `addJoinClause`
+  - Pattern: Resolve aliased targets during traversal while maintaining relationship names for SQL
+**Acceptance Criteria**:
+- Entity field paths correctly traverse through aliased model relationships
+- Entity relationships can themselves be aliased (`aliased` field in EntityRelation)
+- Entity view joins use correct aliased target tables
+- Proper validation for entity-level aliased references
+
+### Task 6: Aliasing Validation & Error Handling
+**Status**: Ready
+**Scope**: Comprehensive validation for aliased relationship configurations
+**Acceptance Criteria**:
+- Validates `aliased` property contains valid model/entity names
+- **Advanced**: Validates polymorphic inverse aliasing pattern (`HasOnePoly` + `through` + `aliased`)
+- Prevents duplicate aliases pointing to same target within same model/entity
+- Clear error messages for invalid aliased references
+- Prevents circular aliasing references
+
+### Task 7: Integration Testing & Documentation
+**Status**: Ready
+**Scope**: End-to-end testing with comprehensive aliasing examples
+**Acceptance Criteria**:
+- Complete aliased relationship examples in testdata (all relationship types)
+- **Advanced**: Polymorphic inverse aliasing examples and validation
+- Generated SQL matches expected aliased schema (tables, columns, constraints)
+- All relationship + aliasing combinations tested at model and entity levels
+- Integration test covers full aliasing pipeline
+
+## 3. Technical Possibilities & Trade-offs
+
+### Alias Naming Strategy
+**Options**:
+1. Direct alias substitution: `{alias_name}_id` (Chosen)
+2. Prefixed aliasing: `alias_{alias_name}_id`
+3. Suffixed aliasing: `{alias_name}_alias_id`
+
+**Trade-offs**:
+- **Chosen**: Clean, intuitive naming that matches relationship alias directly
+- **Prefixed**: Clear alias indication but verbose
+- **Suffixed**: Distinguishable but less intuitive
+
+### Junction Table Naming
+**Options**:
+1. `{source_table}_{alias_name}` (Chosen)
+2. `{source_table}_{alias_name}_{target_table}`
+3. `{source_table}_to_{alias_name}`
+
+**Trade-offs**:
+- **Chosen**: Consistent with current ForMany pattern, concise
+- **With target**: More explicit but potentially very long names
+- **With preposition**: Clear but breaks existing conventions
+
+### Aliased Target Resolution
+**Options**:
+1. Runtime target resolution from `aliased` field (Chosen)
+2. Preprocessing to expand aliases into direct references
+3. Dual storage of both alias and target names
+
+**Trade-offs**:
+- **Chosen**: Flexible, maintains alias semantics throughout pipeline
+- **Preprocessing**: Simpler processing but loses alias context
+- **Dual storage**: Redundant but faster lookups
+
+### Validation Strategy
+**Options**:
+1. Registry-based validation during model loading (Chosen)
+2. Lazy validation during SQL generation
+3. Two-phase validation (structure + references)
+
+**Trade-offs**:
+- **Chosen**: Early error detection, consistent with existing patterns
+- **Lazy**: Simpler but errors discovered late in process
+- **Two-phase**: Comprehensive but complex implementation
+
+### Entity Field Path Resolution
+**Options**:
+1. Alias-aware path traversal during entity compilation (Chosen)
+2. Alias expansion before field path processing
+3. Virtual field mapping for aliased relationships
+
+**Trade-offs**:
+- **Chosen**: Maintains full alias semantics in entity definitions
+- **Expansion**: Simpler but loses alias context in entities
+- **Virtual mapping**: Flexible but adds complexity layer
+
+## 4. Active Working Log
+
+| Task | Status | Commit/PR | Notes |
+|------|--------|-----------|-------|
+| **Task 1** Complete morphe-go Aliasing | ✅ **Done** | morphe-go v0.0.0-20250824082856 | **COMPLETED**: All tests passing, includes polymorphic inverse validation |
+| **Task 2** ForOne/HasOne Aliasing | Ready | - | **READY**: Specific code locations identified |
+| **Task 3** ForMany/HasMany Aliasing | Ready | - | **READY**: Junction table handling identified |
+| **Task 4** Polymorphic Aliasing | Ready | - | **READY**: Includes polymorphic inverse pattern |
+| **Task 5** Entity-Level Aliasing | Ready | - | **READY**: Join traversal updates identified |
+| **Task 6** Aliasing Validation | Partial | - | **PARTIAL**: Polymorphic inverse ✅, duplicates/circular pending |
+| **Task 7** Integration Testing | Ready | - | **READY**: Requires implementation first |
+
+## 5. Status Updates
+
+### 2025-01-02 - Initial Analysis Completed
+- Analyzed existing relationship processing architecture
+- Identified gap between current implementation and aliasing requirements
+- Created comprehensive implementation plan with 7 focused tasks
+- Established cross-repo dependency strategy with batched morphe-go changes
+
+### 2025-01-02 - Task 1 Complete ✅
+- **COMPLETED**: All morphe-go aliasing support with comprehensive testing
+- Added `aliased` field to ModelRelation and EntityRelation structures
+- Implemented aliasing detection functions in yamlops (IsRelationAliased, GetRelationTargetName)
+- Added comprehensive validation including polymorphic inverse validation
+- Added whitespace normalization for all string fields including aliased
+- **DISCOVERED**: Advanced polymorphic inverse aliasing pattern for type generation
+
+### 2025-01-15 - Integration Audit Complete
+- **AUDITED**: Complete scan of plugin-morphe-psql-types for integration points
+- **IDENTIFIED**: 6 key functions requiring updates across 2 main files
+- **PATTERN**: Consistent fix using `yamlops.GetRelationTargetName(relationName, relation.Aliased)`
+- **STRATEGY**: Use aliased target for model/entity lookups, maintain relationship name for SQL objects
+- **COMPATIBILITY**: All changes maintain backward compatibility by preserving column/table naming
+
+---
+
+## Relationship Aliasing Specification Reference
+
+### Supported Aliased Relation Types
+
+* **ForOne Aliased**: Direct relationship with alias - current model belongs to one instance of target model via alias
+  * Implementation: Aliased foreign key column on model table
+  * Example: Person ForOne WorkContact (aliased: ContactInfo), Person ForOne HomeContact (aliased: ContactInfo)
+
+* **ForMany Aliased**: Many-to-many relationship with alias via junction table
+  * Implementation: Aliased junction table with proper naming
+  * Example: Person ForMany WorkProjects (aliased: Project), Person ForMany HobbyProjects (aliased: Project)
+
+* **HasOne Aliased**: Inverse of ForOne with alias - current model can have one model referring to it via alias
+  * Implementation: Validates through aliased ForOne relationship
+  * Example: ContactInfo HasOne WorkPerson (through: WorkContact), ContactInfo HasOne HomePerson (through: HomeContact)
+
+* **HasMany Aliased**: Inverse of ForMany with alias - current model can have multiple models referring to it via alias
+  * Implementation: Validates through aliased ForMany relationship
+  * Example: Project HasMany WorkPeople (through: WorkProjects), Project HasMany HobbyPeople (through: HobbyProjects)
+
+* **Polymorphic Aliased**: All polymorphic types support aliasing with `for` and `through` properties
+  * Implementation: Aliased polymorphic columns and junction tables
+  * Example: Comment ForOnePoly WorkCommentable (aliased: Commentable, for: [WorkDocument, WorkTask])
+
+* **🆕 Polymorphic Inverse Aliased**: Advanced pattern for semantic field naming in generated types
+  * **Pattern**: `HasOnePoly`/`HasManyPoly` with `through` + `aliased` properties
+  * **Purpose**: Create semantic field names for inverse polymorphic relationships
+  * **Example**: 
+    ```yaml
+    # Comment model defines polymorphic interface
+    Comment:
+      related:
+        Commentable:
+          type: ForOnePoly
+          for: [Post, Article, Task]
+    
+    # Post model creates semantic field name
+    Post:
+      related:
+        Note:  # ← Field name in generated types (semantic alias)
+          type: HasOnePoly
+          through: Commentable  # ← References polymorphic relationship name
+          aliased: Comment      # ← Actual model type
+    ```
+  * **Generated Types**:
+    ```go
+    type Post struct {
+        Note *Comment  // Field: "Note", Type: Comment
+    }
+    
+    type Task struct {
+        StatusUpdate *Comment  // Field: "StatusUpdate", Type: Comment
+    }
+    ```
+  * **Validation Requirements**:
+    - `aliased` model must exist in registry
+    - `aliased` model must have polymorphic relationship named `through`
+    - Current model must be in `for` list of that polymorphic relationship
+  * **SQL Impact**: Minimal - `HasOnePoly` doesn't create database columns, only inverse semantics
+
+### Configuration Format
+
+```yaml
+# Model-level aliasing
+related:
+  WorkContact:
+    type: ForOne
+    aliased: ContactInfo
+  HomeContact:
+    type: ForOne
+    aliased: ContactInfo
+  
+  WorkProjects:
+    type: ForMany
+    aliased: Project
+  HobbyProjects:
+    type: ForMany
+    aliased: Project
+
+  # 🆕 Advanced: Polymorphic inverse aliasing
+  Note:
+    type: HasOnePoly
+    through: Commentable
+    aliased: Comment
+  StatusUpdate:
+    type: HasOnePoly
+    through: Commentable
+    aliased: Comment
+
+# Entity-level aliasing (referencing aliased model relationships)
+related:
+  WorkContact:
+    type: ForOne
+    # Inherits aliasing from model relationship
+    
+  # Entity-level aliasing itself
+  PrimaryContact:
+    type: ForOne
+    aliased: ContactInfo
+```
+
+### Database Implementation
+
+- **Aliased Columns**: Foreign key columns use alias names (`work_contact_id`, `home_contact_id`)
+- **Aliased Tables**: Junction tables use alias names (`people_work_projects`, `people_hobby_projects`)  
+- **Aliased Constraints**: Foreign keys and unique constraints incorporate alias names
+- **Target Resolution**: Runtime resolution of aliased target models for validation and SQL generation
+- **Polymorphic Inverse**: No additional SQL schema - purely for type generation semantics 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/kalo-build/clone v0.0.0-20250329082958-41db0353412f
 	github.com/kalo-build/go-util v0.0.0-20250329083327-00e97aeff9b7
-	github.com/kalo-build/morphe-go v0.0.0-20250824082856-62352ec5b6a9
+	github.com/kalo-build/morphe-go v0.0.0-20251016080731-9aae9ab2af3e
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/kalo-build/clone v0.0.0-20250329082958-41db0353412f
 	github.com/kalo-build/go-util v0.0.0-20250329083327-00e97aeff9b7
-	github.com/kalo-build/morphe-go v0.0.0-20250623074451-f3ae2d996b9a
+	github.com/kalo-build/morphe-go v0.0.0-20250824082856-62352ec5b6a9
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/kalo-build/morphe-go v0.0.0-20250623074451-f3ae2d996b9a h1:svhBHF3iUq
 github.com/kalo-build/morphe-go v0.0.0-20250623074451-f3ae2d996b9a/go.mod h1:89ihkv1NRJoTFfE6nBTF2mA0A6cYAi8WuEZ2S6p1JB4=
 github.com/kalo-build/morphe-go v0.0.0-20250824082856-62352ec5b6a9 h1:yJBiV324EUhgTEf/qxKS4vHyUjch0AlUNuHUhX+n5hk=
 github.com/kalo-build/morphe-go v0.0.0-20250824082856-62352ec5b6a9/go.mod h1:89ihkv1NRJoTFfE6nBTF2mA0A6cYAi8WuEZ2S6p1JB4=
+github.com/kalo-build/morphe-go v0.0.0-20251016080731-9aae9ab2af3e h1:zG+lRSE8FXNhBfZI76zpBn4kgSw2Ab+qByhWKJf4w+U=
+github.com/kalo-build/morphe-go v0.0.0-20251016080731-9aae9ab2af3e/go.mod h1:89ihkv1NRJoTFfE6nBTF2mA0A6cYAi8WuEZ2S6p1JB4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/kalo-build/morphe-go v0.0.0-20250511134843-65425ae83c83 h1:ax62CdwsnS
 github.com/kalo-build/morphe-go v0.0.0-20250511134843-65425ae83c83/go.mod h1:89ihkv1NRJoTFfE6nBTF2mA0A6cYAi8WuEZ2S6p1JB4=
 github.com/kalo-build/morphe-go v0.0.0-20250623074451-f3ae2d996b9a h1:svhBHF3iUqQPd5ekNizyqZYFANsogCxF+ZgWAt+7jg4=
 github.com/kalo-build/morphe-go v0.0.0-20250623074451-f3ae2d996b9a/go.mod h1:89ihkv1NRJoTFfE6nBTF2mA0A6cYAi8WuEZ2S6p1JB4=
+github.com/kalo-build/morphe-go v0.0.0-20250824082856-62352ec5b6a9 h1:yJBiV324EUhgTEf/qxKS4vHyUjch0AlUNuHUhX+n5hk=
+github.com/kalo-build/morphe-go v0.0.0-20250824082856-62352ec5b6a9/go.mod h1:89ihkv1NRJoTFfE6nBTF2mA0A6cYAi8WuEZ2S6p1JB4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/pkg/compile/compile_entities.go
+++ b/pkg/compile/compile_entities.go
@@ -188,14 +188,17 @@ func processFieldPath(ctx *entityCompileContext, fieldName string, relationshipC
 		}
 
 		// Handle regular relationships - set up join and continue traversal
+		// Use relationName for table naming to maintain backward compatibility
 		relatedTableName := Pluralize(strcase.ToSnakeCaseLower(relationName))
 
 		// Record that we need a join to this table
 		ctx.joinTables[relatedTableName] = true
+		// Store the relationship name for join setup (keeping existing behavior)
 		ctx.joinTableRelationships[relatedTableName] = relationName
 
-		// Update current context for next iteration
-		currentModelName = relationName
+		// Update current context for next iteration - use the actual target model
+		targetModelName := yamlops.GetRelationTargetName(relationName, relation.Aliased)
+		currentModelName = targetModelName
 		currentTableName = relatedTableName
 	}
 

--- a/pkg/compile/compile_entities.go
+++ b/pkg/compile/compile_entities.go
@@ -65,7 +65,7 @@ func morpheEntityToPSQLView(config cfg.MorpheConfig, r *registry.Registry, entit
 		return nil, validateConfigErr
 	}
 
-	validateEntityErr := entity.Validate(r.GetAllModels(), r.GetAllEnums())
+	validateEntityErr := entity.Validate(r.GetAllEntities(), r.GetAllModels(), r.GetAllEnums())
 	if validateEntityErr != nil {
 		return nil, validateEntityErr
 	}

--- a/pkg/compile/compile_entities.go
+++ b/pkg/compile/compile_entities.go
@@ -87,13 +87,12 @@ func morpheEntityToPSQLView(config cfg.MorpheConfig, r *registry.Registry, entit
 	}
 
 	context := &entityCompileContext{
-		config:                 config,
-		registry:               r,
-		entity:                 entity,
-		view:                   view,
-		tableName:              tableName,
-		joinTables:             make(map[string]bool),
-		joinTableRelationships: make(map[string]string),
+		config:    config,
+		registry:  r,
+		entity:    entity,
+		view:      view,
+		tableName: tableName,
+		joins:     make(map[string]joinInfo),
 	}
 
 	if err := processEntityFields(context); err != nil {
@@ -107,15 +106,20 @@ func morpheEntityToPSQLView(config cfg.MorpheConfig, r *registry.Registry, entit
 	return view, nil
 }
 
+// joinInfo holds information about a join relationship
+type joinInfo struct {
+	relationshipName string // The name of the relationship (e.g., "WorkContact")
+	sourceModelName  string // The model that owns this relationship (e.g., "Person")
+}
+
 // entityCompileContext holds all the context needed for entity compilation
 type entityCompileContext struct {
-	config                 cfg.MorpheConfig
-	registry               *registry.Registry
-	entity                 yaml.Entity
-	view                   *psqldef.View
-	tableName              string
-	joinTables             map[string]bool
-	joinTableRelationships map[string]string
+	config    cfg.MorpheConfig
+	registry  *registry.Registry
+	entity    yaml.Entity
+	view      *psqldef.View
+	tableName string
+	joins     map[string]joinInfo // maps join table name to join information
 }
 
 // processEntityFields processes all entity fields and adds appropriate columns to the view
@@ -191,10 +195,11 @@ func processFieldPath(ctx *entityCompileContext, fieldName string, relationshipC
 		// Use relationName for table naming to maintain backward compatibility
 		relatedTableName := Pluralize(strcase.ToSnakeCaseLower(relationName))
 
-		// Record that we need a join to this table
-		ctx.joinTables[relatedTableName] = true
-		// Store the relationship name for join setup (keeping existing behavior)
-		ctx.joinTableRelationships[relatedTableName] = relationName
+		// Record join information for this table
+		ctx.joins[relatedTableName] = joinInfo{
+			relationshipName: relationName,
+			sourceModelName:  currentModelName,
+		}
 
 		// Update current context for next iteration - use the actual target model
 		targetModelName := yamlops.GetRelationTargetName(relationName, relation.Aliased)
@@ -303,13 +308,12 @@ func addRegularColumn(ctx *entityCompileContext, columnName, tableName, fieldNam
 
 // setupJoinsForRegularRelationships sets up joins for all recorded regular relationships
 func setupJoinsForRegularRelationships(ctx *entityCompileContext) error {
-	for joinTable := range ctx.joinTables {
-		relatedModelName := ctx.joinTableRelationships[joinTable]
-		if relatedModelName == "" {
-			continue
-		}
+	// Sort join tables for deterministic order
+	sortedJoinTables := core.MapKeysSorted(ctx.joins)
 
-		if err := addJoinClause(ctx, joinTable, relatedModelName); err != nil {
+	for _, joinTable := range sortedJoinTables {
+		joinInfo := ctx.joins[joinTable]
+		if err := addJoinClause(ctx, joinTable, joinInfo); err != nil {
 			return err
 		}
 	}
@@ -317,25 +321,25 @@ func setupJoinsForRegularRelationships(ctx *entityCompileContext) error {
 }
 
 // addJoinClause adds a single join clause to the view
-func addJoinClause(ctx *entityCompileContext, joinTable, relatedModelName string) error {
-	model, err := ctx.registry.GetModel(ctx.entity.Name)
+func addJoinClause(ctx *entityCompileContext, joinTable string, info joinInfo) error {
+	model, err := ctx.registry.GetModel(info.sourceModelName)
 	if err != nil {
-		return err
+		return fmt.Errorf("model %s not found in registry", info.sourceModelName)
 	}
 
-	_, relationshipExists := model.Related[relatedModelName]
+	_, relationshipExists := model.Related[info.relationshipName]
 	if !relationshipExists {
-		return fmt.Errorf("relationship %s not found in model %s", relatedModelName, ctx.entity.Name)
+		return fmt.Errorf("relationship %s not found in model %s", info.relationshipName, info.sourceModelName)
 	}
 
 	rootPrimaryId, rootExists := model.Identifiers["primary"]
 	if !rootExists {
-		return fmt.Errorf("primary identifier not found in model '%s'", ctx.entity.Name)
+		return fmt.Errorf("primary identifier not found in model '%s'", info.sourceModelName)
 	}
 
 	relatedPrimaryId, relatedExists := model.Identifiers["primary"]
 	if !relatedExists {
-		return fmt.Errorf("primary identifier not found in model '%s'", relatedModelName)
+		return fmt.Errorf("primary identifier not found in model '%s'", info.relationshipName)
 	}
 
 	rootPrimaryIdName := strcase.ToSnakeCaseLower(rootPrimaryId.Fields[0])

--- a/pkg/compile/compile_entities_test.go
+++ b/pkg/compile/compile_entities_test.go
@@ -1547,33 +1547,23 @@ func (suite *CompileEntitiesTestSuite) TestMorpheEntityToPSQLView_FieldPath_Alia
 	suite.Equal("name", view.Columns[1].Name)
 	suite.Equal("person_profiles.name", view.Columns[1].SourceRef)
 
-	suite.Equal("work_email", view.Columns[2].Name)
-	suite.Equal("work_contacts.email", view.Columns[2].SourceRef)
+	suite.Equal("personal_email", view.Columns[2].Name)
+	suite.Equal("personal_contacts.email", view.Columns[2].SourceRef)
 
-	suite.Equal("work_phone", view.Columns[3].Name)
-	suite.Equal("work_contacts.phone", view.Columns[3].SourceRef)
+	suite.Equal("personal_phone", view.Columns[3].Name)
+	suite.Equal("personal_contacts.phone", view.Columns[3].SourceRef)
 
-	suite.Equal("personal_email", view.Columns[4].Name)
-	suite.Equal("personal_contacts.email", view.Columns[4].SourceRef)
+	suite.Equal("work_email", view.Columns[4].Name)
+	suite.Equal("work_contacts.email", view.Columns[4].SourceRef)
 
-	suite.Equal("personal_phone", view.Columns[5].Name)
-	suite.Equal("personal_contacts.phone", view.Columns[5].SourceRef)
+	suite.Equal("work_phone", view.Columns[5].Name)
+	suite.Equal("work_contacts.phone", view.Columns[5].SourceRef)
 
 	// Check joins - there should be 2 joins for the aliased relationships
 	suite.Len(view.Joins, 2)
 
-	// Join for WorkContact (uses relationship name for table alias)
-	workJoin := view.Joins[0]
-	suite.Equal("LEFT", workJoin.Type)
-	suite.Equal("public", workJoin.Schema)
-	suite.Equal("work_contacts", workJoin.Table)
-	suite.Equal("work_contacts", workJoin.Alias)
-	suite.Len(workJoin.Conditions, 1)
-	suite.Equal("person_profiles.id", workJoin.Conditions[0].LeftRef)
-	suite.Equal("work_contacts.id", workJoin.Conditions[0].RightRef)
-
-	// Join for PersonalContact (uses relationship name for table alias)
-	personalJoin := view.Joins[1]
+	// Join for PersonalContact (processed first alphabetically)
+	personalJoin := view.Joins[0]
 	suite.Equal("LEFT", personalJoin.Type)
 	suite.Equal("public", personalJoin.Schema)
 	suite.Equal("personal_contacts", personalJoin.Table)
@@ -1581,6 +1571,16 @@ func (suite *CompileEntitiesTestSuite) TestMorpheEntityToPSQLView_FieldPath_Alia
 	suite.Len(personalJoin.Conditions, 1)
 	suite.Equal("person_profiles.id", personalJoin.Conditions[0].LeftRef)
 	suite.Equal("personal_contacts.id", personalJoin.Conditions[0].RightRef)
+
+	// Join for WorkContact (processed second alphabetically)
+	workJoin := view.Joins[1]
+	suite.Equal("LEFT", workJoin.Type)
+	suite.Equal("public", workJoin.Schema)
+	suite.Equal("work_contacts", workJoin.Table)
+	suite.Equal("work_contacts", workJoin.Alias)
+	suite.Len(workJoin.Conditions, 1)
+	suite.Equal("person_profiles.id", workJoin.Conditions[0].LeftRef)
+	suite.Equal("work_contacts.id", workJoin.Conditions[0].RightRef)
 }
 
 // TestMorpheModelToPSQLTables_Aliased_ErrorHandling tests error cases for aliased relationships
@@ -1617,20 +1617,6 @@ func (suite *CompileEntitiesTestSuite) TestMorpheModelToPSQLTables_Aliased_Error
 	suite.NotNil(err)
 	suite.Contains(err.Error(), "NonExistentModel")
 }
-
-// Note: Full entity field path testing with aliased relationships requires
-// morphe-go to support aliasing in entity validation. Currently, the validation
-// happens before our compilation code can resolve aliases.
-// Once morphe-go is updated, the TestMorpheEntityToPSQLView_FieldPath_AliasedRelationships
-// test below can be uncommented and used.
-
-/*
-func (suite *CompileEntitiesTestSuite) TestMorpheEntityToPSQLView_FieldPath_AliasedRelationships() {
-
-// ... existing code ...
-
-}
-*/
 
 // Test entity views with polymorphic aliased relationships
 func (suite *CompileEntitiesTestSuite) TestMorpheEntityToPSQLView_ForOnePoly_Aliased() {

--- a/pkg/compile/compile_entities_test.go
+++ b/pkg/compile/compile_entities_test.go
@@ -1528,7 +1528,7 @@ func (suite *CompileEntitiesTestSuite) TestMorpheEntityToPSQLView_FieldPath_Alia
 	if err != nil {
 		suite.T().Logf("Error compiling entity: %v", err)
 	}
-	
+
 	suite.Nil(err)
 	suite.NotNil(view)
 
@@ -1540,22 +1540,22 @@ func (suite *CompileEntitiesTestSuite) TestMorpheEntityToPSQLView_FieldPath_Alia
 
 	// Check columns
 	suite.Len(view.Columns, 6) // id, name, work_email, work_phone, personal_email, personal_phone
-	
+
 	suite.Equal("id", view.Columns[0].Name)
 	suite.Equal("person_profiles.id", view.Columns[0].SourceRef)
-	
+
 	suite.Equal("name", view.Columns[1].Name)
 	suite.Equal("person_profiles.name", view.Columns[1].SourceRef)
-	
+
 	suite.Equal("work_email", view.Columns[2].Name)
 	suite.Equal("work_contacts.email", view.Columns[2].SourceRef)
-	
+
 	suite.Equal("work_phone", view.Columns[3].Name)
 	suite.Equal("work_contacts.phone", view.Columns[3].SourceRef)
-	
+
 	suite.Equal("personal_email", view.Columns[4].Name)
 	suite.Equal("personal_contacts.email", view.Columns[4].SourceRef)
-	
+
 	suite.Equal("personal_phone", view.Columns[5].Name)
 	suite.Equal("personal_contacts.phone", view.Columns[5].SourceRef)
 
@@ -1613,7 +1613,7 @@ func (suite *CompileEntitiesTestSuite) TestMorpheModelToPSQLTables_Aliased_Error
 
 	// Try to compile - should fail
 	_, err := compile.MorpheModelToPSQLTables(config, r, personModel)
-	
+
 	suite.NotNil(err)
 	suite.Contains(err.Error(), "NonExistentModel")
 }
@@ -1631,3 +1631,239 @@ func (suite *CompileEntitiesTestSuite) TestMorpheEntityToPSQLView_FieldPath_Alia
 
 }
 */
+
+// Test entity views with polymorphic aliased relationships
+func (suite *CompileEntitiesTestSuite) TestMorpheEntityToPSQLView_ForOnePoly_Aliased() {
+	config := suite.getCompileConfig()
+
+	// Document model
+	documentModel := yaml.Model{
+		Name: "Document",
+		Fields: map[string]yaml.ModelField{
+			"ID":    {Type: yaml.ModelFieldTypeAutoIncrement},
+			"Title": {Type: yaml.ModelFieldTypeString},
+		},
+		Identifiers: map[string]yaml.ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+		},
+	}
+
+	// Video model
+	videoModel := yaml.Model{
+		Name: "Video",
+		Fields: map[string]yaml.ModelField{
+			"ID":       {Type: yaml.ModelFieldTypeAutoIncrement},
+			"Duration": {Type: yaml.ModelFieldTypeInteger},
+		},
+		Identifiers: map[string]yaml.ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+		},
+	}
+
+	// Comment model with ForOnePoly using alias
+	commentModel := yaml.Model{
+		Name: "Comment",
+		Fields: map[string]yaml.ModelField{
+			"ID":   {Type: yaml.ModelFieldTypeAutoIncrement},
+			"Text": {Type: yaml.ModelFieldTypeString},
+		},
+		Identifiers: map[string]yaml.ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+		},
+		Related: map[string]yaml.ModelRelation{
+			"CommentableResource": {
+				Type:    "ForOnePoly",
+				For:     []string{"Document", "Video"},
+				Aliased: "Resource", // Alias that doesn't map to any model
+			},
+		},
+	}
+
+	// Comment entity
+	commentEntity := yaml.Entity{
+		Name: "CommentView",
+		Fields: map[string]yaml.EntityField{
+			"id":   {Type: "Comment.ID"},
+			"text": {Type: "Comment.Text"},
+		},
+		Identifiers: map[string]yaml.EntityIdentifier{
+			"primary": {Fields: []string{"id"}},
+		},
+		// We can't reference CommentableResource fields due to polymorphic nature
+		Related: map[string]yaml.EntityRelation{},
+	}
+
+	r := registry.NewRegistry()
+	r.SetModel("Document", documentModel)
+	r.SetModel("Video", videoModel)
+	r.SetModel("Comment", commentModel)
+	r.SetEntity("CommentView", commentEntity)
+
+	view, viewErr := compile.MorpheEntityToPSQLView(config, r, commentEntity)
+
+	suite.Nil(viewErr)
+	suite.NotNil(view)
+	suite.Equal("comment_view_entities", view.Name)
+
+	// Should have only the explicitly referenced fields (polymorphic columns are not auto-included)
+	suite.Len(view.Columns, 2) // id, text
+
+	// Verify the columns
+	suite.Equal("id", view.Columns[0].Name)
+	suite.Equal("comment_views.id", view.Columns[0].SourceRef)
+
+	suite.Equal("text", view.Columns[1].Name)
+	suite.Equal("comment_views.text", view.Columns[1].SourceRef)
+
+	// Should have no joins for polymorphic relationships
+	suite.Len(view.Joins, 0)
+}
+
+// Test entity views with ForManyPoly aliased relationships
+func (suite *CompileEntitiesTestSuite) TestMorpheEntityToPSQLView_ForManyPoly_Aliased() {
+	config := suite.getCompileConfig()
+
+	// Document model
+	documentModel := yaml.Model{
+		Name: "Document",
+		Fields: map[string]yaml.ModelField{
+			"ID": {Type: yaml.ModelFieldTypeAutoIncrement},
+		},
+		Identifiers: map[string]yaml.ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+		},
+	}
+
+	// Project model
+	projectModel := yaml.Model{
+		Name: "Project",
+		Fields: map[string]yaml.ModelField{
+			"ID": {Type: yaml.ModelFieldTypeAutoIncrement},
+		},
+		Identifiers: map[string]yaml.ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+		},
+	}
+
+	// Tag model with ForManyPoly using alias
+	tagModel := yaml.Model{
+		Name: "Tag",
+		Fields: map[string]yaml.ModelField{
+			"ID":   {Type: yaml.ModelFieldTypeAutoIncrement},
+			"Name": {Type: yaml.ModelFieldTypeString},
+		},
+		Identifiers: map[string]yaml.ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+		},
+		Related: map[string]yaml.ModelRelation{
+			"TaggedItems": {
+				Type:    "ForManyPoly",
+				For:     []string{"Document", "Project"},
+				Aliased: "Item", // Alias
+			},
+		},
+	}
+
+	// Tag entity
+	tagEntity := yaml.Entity{
+		Name: "TagView",
+		Fields: map[string]yaml.EntityField{
+			"id":   {Type: "Tag.ID"},
+			"name": {Type: "Tag.Name"},
+		},
+		Identifiers: map[string]yaml.EntityIdentifier{
+			"primary": {Fields: []string{"id"}},
+		},
+		Related: map[string]yaml.EntityRelation{},
+	}
+
+	r := registry.NewRegistry()
+	r.SetModel("Document", documentModel)
+	r.SetModel("Project", projectModel)
+	r.SetModel("Tag", tagModel)
+	r.SetEntity("TagView", tagEntity)
+
+	view, viewErr := compile.MorpheEntityToPSQLView(config, r, tagEntity)
+
+	suite.Nil(viewErr)
+	suite.NotNil(view)
+	suite.Equal("tag_view_entities", view.Name)
+
+	// ForManyPoly should be simple - only regular fields, no junction table materialization
+	suite.Len(view.Columns, 2) // Only id and name
+
+	// Should have no joins for ForManyPoly relationships
+	suite.Len(view.Joins, 0)
+}
+
+// Test the polymorphic inverse aliasing pattern in entities
+func (suite *CompileEntitiesTestSuite) TestMorpheEntityToPSQLView_HasOnePoly_Aliased() {
+	config := suite.getCompileConfig()
+
+	// Comment model with ForOnePoly
+	commentModel := yaml.Model{
+		Name: "Comment",
+		Fields: map[string]yaml.ModelField{
+			"ID":   {Type: yaml.ModelFieldTypeAutoIncrement},
+			"Text": {Type: yaml.ModelFieldTypeString},
+		},
+		Identifiers: map[string]yaml.ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+		},
+		Related: map[string]yaml.ModelRelation{
+			"Commentable": {
+				Type: "ForOnePoly",
+				For:  []string{"Post", "Task"},
+			},
+		},
+	}
+
+	// Post model with semantic alias
+	postModel := yaml.Model{
+		Name: "Post",
+		Fields: map[string]yaml.ModelField{
+			"ID":    {Type: yaml.ModelFieldTypeAutoIncrement},
+			"Title": {Type: yaml.ModelFieldTypeString},
+		},
+		Identifiers: map[string]yaml.ModelIdentifier{
+			"primary": {Fields: []string{"ID"}},
+		},
+		Related: map[string]yaml.ModelRelation{
+			"Note": { // Semantic field name
+				Type:    "HasOnePoly",
+				Through: "Commentable",
+				Aliased: "Comment",
+			},
+		},
+	}
+
+	// Post entity
+	postEntity := yaml.Entity{
+		Name: "PostView",
+		Fields: map[string]yaml.EntityField{
+			"id":    {Type: "Post.ID"},
+			"title": {Type: "Post.Title"},
+		},
+		Identifiers: map[string]yaml.EntityIdentifier{
+			"primary": {Fields: []string{"id"}},
+		},
+		Related: map[string]yaml.EntityRelation{},
+	}
+
+	r := registry.NewRegistry()
+	r.SetModel("Comment", commentModel)
+	r.SetModel("Post", postModel)
+	r.SetEntity("PostView", postEntity)
+
+	view, viewErr := compile.MorpheEntityToPSQLView(config, r, postEntity)
+
+	suite.Nil(viewErr)
+	suite.NotNil(view)
+	suite.Equal("post_view_entities", view.Name)
+
+	// HasOnePoly should not be materialized - only regular fields
+	suite.Len(view.Columns, 2) // Only id and title
+
+	// Should have no joins for HasOnePoly relationships
+	suite.Len(view.Joins, 0)
+}

--- a/pkg/compile/compile_models.go
+++ b/pkg/compile/compile_models.go
@@ -207,6 +207,8 @@ func getColumnsForModelRelations(r *registry.Registry, typeMap map[yaml.ModelFie
 	for _, relatedModelName := range relatedModelNames {
 		modelRelation := relatedModels[relatedModelName]
 		relationType := modelRelation.Type
+		// Resolve the actual target model name using aliasing
+		targetModelName := yamlops.GetRelationTargetName(relatedModelName, modelRelation.Aliased)
 
 		if yamlops.IsRelationPolyFor(relationType) && yamlops.IsRelationPolyOne(relationType) {
 			typeColumnName := strcase.ToSnakeCaseLower(relatedModelName) + "_type"
@@ -235,26 +237,28 @@ func getColumnsForModelRelations(r *registry.Registry, typeMap map[yaml.ModelFie
 			continue
 		}
 
-		relatedModel, modelErr := r.GetModel(relatedModelName)
+		// Use targetModelName for model lookup, but keep relatedModelName for column naming
+		relatedModel, modelErr := r.GetModel(targetModelName)
 		if modelErr != nil {
 			return nil, modelErr
 		}
 		primaryID, hasPrimary := relatedModel.Identifiers["primary"]
 		if !hasPrimary {
-			return nil, fmt.Errorf("related model %s has no primary identifier", relatedModelName)
+			return nil, fmt.Errorf("related model %s has no primary identifier", targetModelName)
 		}
 
 		if len(primaryID.Fields) != 1 {
-			return nil, fmt.Errorf("related entity %s primary identifier must have exactly one field", relatedModelName)
+			return nil, fmt.Errorf("related entity %s primary identifier must have exactly one field", targetModelName)
 		}
 
 		targetPrimaryIdName := primaryID.Fields[0]
 		targetPrimaryIdField, primaryFieldExists := relatedModel.Fields[targetPrimaryIdName]
 		if !primaryFieldExists {
-			return nil, fmt.Errorf("related entity %s primary identifier field %s not found", relatedModelName, targetPrimaryIdName)
+			return nil, fmt.Errorf("related entity %s primary identifier field %s not found", targetModelName, targetPrimaryIdName)
 		}
 
 		if yamlops.IsRelationFor(relationType) && yamlops.IsRelationOne(relationType) {
+			// Use relatedModelName for column naming to maintain backward compatibility
 			columnName := GetForeignKeyColumnName(relatedModelName, targetPrimaryIdName)
 
 			columnType, supported := typeMap[targetPrimaryIdField.Type]
@@ -284,33 +288,38 @@ func getForeignKeysForModelRelations(schema string, tableName string, r *registr
 	for _, relatedModelName := range relatedModelNames {
 		modelRelation := relatedModels[relatedModelName]
 		relationType := modelRelation.Type
+		// Resolve the actual target model name using aliasing
+		targetModelName := yamlops.GetRelationTargetName(relatedModelName, modelRelation.Aliased)
 
 		if yamlops.IsRelationPoly(relationType) {
 			continue
 		}
 
-		relatedModel, modelErr := r.GetModel(relatedModelName)
+		// Use targetModelName for model lookup
+		relatedModel, modelErr := r.GetModel(targetModelName)
 		if modelErr != nil {
 			return nil, modelErr
 		}
 		primaryID, hasPrimary := relatedModel.Identifiers["primary"]
 		if !hasPrimary {
-			return nil, fmt.Errorf("related model %s has no primary identifier", relatedModelName)
+			return nil, fmt.Errorf("related model %s has no primary identifier", targetModelName)
 		}
 
 		if len(primaryID.Fields) != 1 {
-			return nil, fmt.Errorf("related entity %s primary identifier must have exactly one field", relatedModelName)
+			return nil, fmt.Errorf("related entity %s primary identifier must have exactly one field", targetModelName)
 		}
 
 		targetPrimaryIdName := primaryID.Fields[0]
 		_, primaryFieldExists := relatedModel.Fields[targetPrimaryIdName]
 		if !primaryFieldExists {
-			return nil, fmt.Errorf("related entity %s primary identifier field %s not found", relatedModelName, targetPrimaryIdName)
+			return nil, fmt.Errorf("related entity %s primary identifier field %s not found", targetModelName, targetPrimaryIdName)
 		}
 
 		if yamlops.IsRelationFor(relationType) && yamlops.IsRelationOne(relationType) {
+			// Use relatedModelName for column naming to maintain backward compatibility
 			columnName := GetForeignKeyColumnName(relatedModelName, targetPrimaryIdName)
-			refTableName := GetTableNameFromModel(relatedModelName)
+			// Use targetModelName for the reference table
+			refTableName := GetTableNameFromModel(targetModelName)
 			refColumnName := GetColumnNameFromField(targetPrimaryIdName)
 
 			foreignKey := psqldef.ForeignKey{
@@ -408,9 +417,12 @@ func getJunctionTablesForForManyRelations(schema string, r *registry.Registry, m
 	for _, relatedModelName := range relatedModelNames {
 		modelRelation := model.Related[relatedModelName]
 		relationType := modelRelation.Type
+		// Resolve the actual target model name using aliasing
+		targetModelName := yamlops.GetRelationTargetName(relatedModelName, modelRelation.Aliased)
 
 		if yamlops.IsRelationFor(relationType) && yamlops.IsRelationMany(relationType) && !yamlops.IsRelationPoly(relationType) {
-			relatedModel, modelErr := r.GetModel(relatedModelName)
+			// Use targetModelName for model lookup
+			relatedModel, modelErr := r.GetModel(targetModelName)
 			if modelErr != nil {
 				return nil, modelErr
 			}
@@ -418,17 +430,17 @@ func getJunctionTablesForForManyRelations(schema string, r *registry.Registry, m
 			// Get primary ID field for related model
 			relatedPrimaryID, hasRelatedPrimary := relatedModel.Identifiers["primary"]
 			if !hasRelatedPrimary {
-				return nil, fmt.Errorf("related model %s has no primary identifier", relatedModelName)
+				return nil, fmt.Errorf("related model %s has no primary identifier", targetModelName)
 			}
 			if len(relatedPrimaryID.Fields) != 1 {
-				return nil, fmt.Errorf("related model %s primary identifier must have exactly one field", relatedModelName)
+				return nil, fmt.Errorf("related model %s primary identifier must have exactly one field", targetModelName)
 			}
 			relatedPrimaryIdName := relatedPrimaryID.Fields[0]
 
-			// Create junction table
+			// Create junction table - use relatedModelName for naming to maintain backward compatibility
 			junctionTableName := GetJunctionTableName(modelName, relatedModelName)
 
-			// Create column names
+			// Create column names - use relationship names for columns
 			sourceColumnName := GetForeignKeyColumnName(modelName, primaryIdName)
 			targetColumnName := GetForeignKeyColumnName(relatedModelName, relatedPrimaryIdName)
 
@@ -465,11 +477,13 @@ func getJunctionTablesForForManyRelations(schema string, r *registry.Registry, m
 				},
 				{
 					Schema:       schema,
+					// Use relatedModelName for constraint naming
 					Name:         GetJunctionTableForeignKeyConstraintName(junctionTableName, relatedModelName, relatedPrimaryIdName),
 					TableName:    junctionTableName,
 					ColumnNames:  []string{targetColumnName},
 					RefSchema:    schema,
-					RefTableName: GetTableNameFromModel(relatedModelName),
+					// Use targetModelName for the reference table
+					RefTableName: GetTableNameFromModel(targetModelName),
 					RefColumnNames: []string{
 						GetColumnNameFromField(relatedPrimaryIdName),
 					},
@@ -477,7 +491,7 @@ func getJunctionTablesForForManyRelations(schema string, r *registry.Registry, m
 				},
 			}
 
-			// Create unique constraint
+			// Create unique constraint - use relationship names
 			uniqueConstraints := []psqldef.UniqueConstraint{
 				{
 					Name: GetJunctionTableUniqueConstraintName(

--- a/pkg/compile/compile_models.go
+++ b/pkg/compile/compile_models.go
@@ -860,6 +860,11 @@ func validateAliasedRelations(r *registry.Registry, model yaml.Model) error {
 		
 		// Only validate if the target is different (i.e., aliased)
 		if targetModelName != relationName {
+			// Skip validation for polymorphic relationships - aliases are conceptual names
+			if yamlops.IsRelationPoly(relation.Type) {
+				continue
+			}
+			
 			_, err := r.GetModel(targetModelName)
 			if err != nil {
 				return fmt.Errorf("aliased target model '%s' for relation '%s' in model '%s' not found", 

--- a/polymorphism.md
+++ b/polymorphism.md
@@ -1,0 +1,344 @@
+# Polymorphism Implementation Plan
+
+## 0. Rules & Principles
+
+- **Consistency**: Follow existing codebase patterns (naming conventions, error handling, test structure)
+- **Minimal scope**: Each task focuses on one specific feature implementation
+- **Minimal redundancy**: New code attempts to leverage existing code when there is domain- / usage-level overlap to mitigate code fragmentation and manual update friction
+- **Cohesion <> Coupling**: Apply minimal coupling and maximum cohesion software principles
+- **Idiomatic Go**: Clean, readable code following Go best practices
+- **Clean Code**: Clean code practices like "no deep nesting", early return, SRP, ...
+- **TDD approach**: Red-Green-Refactor cycle with 1-2 refactor loops per task, and tests for realistic edge cases (including error cases)
+- **Testing style**: Use testify assertions; one test per case for simple functions (boolean/regex), arrange-act-assert blocks for complex tests; minimize comments
+- **Human review**: Mandatory pause after each green run for testing and feedback
+- **Backward compatibility**: All changes must not break existing functionality
+- **Database integrity**: All polymorphic tables must maintain referential integrity via constraints
+- **Planning**: After task completion, reevaluate upcoming tasks and revisit adding new / updating existing
+
+## 1. Codebase ⇄ Spec Gap Analysis
+
+### Current State
+- **Supported Relations**: `ForOne`, `ForMany`, `HasOne`, `HasMany` (non-polymorphic)
+- **Junction Tables**: Implemented for `ForMany` relationships
+- **Column Generation**: Foreign key columns for `ForOne` relationships  
+- **Test Coverage**: Comprehensive tests for existing relationship types
+
+### Missing Components for Polymorphism
+
+#### Core Logic Modules
+- `pkg/compile/compile_models.go`: No polymorphic relationship handling
+- **External Dependency**: `morphe-go/pkg/yamlops/`: Missing polymorphic relation detection functions  
+- `pkg/psqldef/`: No polymorphic column types (type + id fields)
+
+#### Database Schema Components
+- **ForOnePoly**: Missing polymorphic type + id column generation
+- **ForManyPoly**: Missing polymorphic junction table creation
+- **HasOnePoly/HasManyPoly**: Missing inverse relationship handling
+- **Polymorphic constraints**: No validation for `for` property in YAML
+
+#### Test Infrastructure
+- No test models with polymorphic relationships
+- No expected SQL output for polymorphic tables
+- Missing validation tests for polymorphic configurations
+
+#### Documentation & Examples
+- No polymorphic model examples in `testdata/`
+- Missing polymorphic schema generation in `ground-truth/`
+
+### Impacted Files
+```
+# External Dependencies (morphe-go repo) - BATCHED CHANGES
+morphe-go/pkg/yamlops/relation.go      - Polymorphic relation detection functions  
+morphe-go/pkg/yamlops/relation_test.go - Tests for polymorphic detection
+morphe-go/pkg/yaml/model_relation.go   - Add 'for' and 'through' fields
+morphe-go/pkg/yaml/entity_relation.go  - Add 'for' and 'through' fields (if needed)
+morphe-go/pkg/yaml/entity.go           - Add polymorphic types to validation
+morphe-go/pkg/yaml/model.go            - Add polymorphic validation logic
+
+# This Repository (plugin-morphe-psql-types)  
+pkg/compile/compile_models.go          - Core polymorphic compilation logic
+pkg/compile/compile_models_test.go     - Test coverage for new features
+pkg/compile/naming.go                  - Polymorphic column/table naming
+pkg/psqldef/                          - Polymorphic column definitions
+testdata/registry/                    - Polymorphic model examples  
+testdata/ground-truth/                - Expected polymorphic SQL output
+```
+
+## 2. Implementation Plan
+
+**Statuses:**
+
+- Ready: Ready to implement (in theory), practical prerequisites not checked
+- In progress: Implementing
+- Review: Ready for review by human
+- Done: Successfully implemented & reviewed by human
+
+### Task 1: Complete morphe-go Polymorphism Support  
+**Status**: Done
+**Scope**: BATCHED cross-repo changes - all morphe-go modifications for polymorphism
+**Cross-Repo Dependency**: Single comprehensive morphe-go update + one dependency sync
+**Sub-tasks**:
+- ✅ **1.1** Polymorphic relation detection functions (yamlops) 
+- ✅ **1.2** ModelRelation structure extensions (`for`, `through` fields)
+- ✅ **1.3** EntityRelation validation updates (add polymorphic types)  
+- ✅ **1.4** Model/Entity validation for polymorphic properties
+- ✅ **1.5** Deep clone method updates
+- ✅ **1.6** Comprehensive morphe-go testing
+
+### Task 2: ForOnePoly Column Generation  
+**Status**: Done
+**Scope**: Generate polymorphic type + id columns for ForOnePoly relationships
+**Acceptance Criteria**:
+- Creates `{relation_name}_type` TEXT column 
+- Creates `{relation_name}_id` TEXT column
+- No foreign key constraints (polymorphic nature)
+- Proper column naming conventions
+
+### Task 3: ForManyPoly Junction Tables
+**Status**: Done
+**Scope**: Generate polymorphic junction tables for ForManyPoly relationships  
+**Acceptance Criteria**:
+- ✅ Junction table with polymorphic type + id columns
+- ✅ Proper unique constraints on (source_id, target_type, target_id)
+- ✅ No foreign key constraints on polymorphic columns
+
+### Task 4: HasOnePoly/HasManyPoly Inverse Relations
+**Status**: Done
+**Scope**: Handle inverse polymorphic relationships using `through` property
+**Acceptance Criteria**:
+- ✅ Validates `through` property points to valid polymorphic relation
+- ✅ No additional column generation (relies on forward relation)
+- ✅ Proper relationship validation
+
+### Task 5: Polymorphic Validation & Error Handling
+**Status**: Done
+**Scope**: Comprehensive validation for polymorphic relationship configurations
+**Acceptance Criteria**:
+- ✅ Validates `for` property contains valid model names
+- ✅ Validates `through` property for Has* relationships  
+- ✅ Clear error messages for misconfigurations
+- ✅ Prevents circular polymorphic references
+
+### Task 6: Integration Testing & Documentation  
+**Status**: Done
+**Scope**: End-to-end testing with comprehensive polymorphic examples
+**Acceptance Criteria**:
+- ✅ Complete polymorphic model examples in testdata (ForOnePoly + ForManyPoly)
+- ✅ Generated SQL matches expected polymorphic schema
+- ✅ All relationship combinations tested at model level
+
+### Task 7: Entity-Level Polymorphic View Generation
+**Status**: Done  
+**Scope**: Generate appropriate entity views for polymorphic relationships
+**Acceptance Criteria**:
+- ✅ ForOnePoly entity views include raw polymorphic columns (type + id)
+- ✅ ForManyPoly entity views are simple (no junction table materialization)
+- ✅ HasOnePoly/HasManyPoly inverse relationships not materialized in entity views
+- ✅ Entity view generation maintains existing patterns
+
+### Task 8: Entity-Level Integration Testing
+**Status**: Done
+**Scope**: Comprehensive testing of polymorphic entity view generation
+**Acceptance Criteria**:
+- ✅ Entity views generated correctly for all polymorphic relationship types
+- ✅ Integration tests cover entity-level polymorphic scenarios  
+- ✅ Generated entity SQL matches expected polymorphic view schema
+- ✅ No regressions in existing entity view functionality
+
+## 3. Technical Possibilities & Trade-offs
+
+### Column Naming Strategy
+**Options**:
+1. `{relation_name}_type` + `{relation_name}_id` (Chosen)
+2. `polymorphic_type` + `polymorphic_id` (Generic)
+
+**Trade-offs**:
+- **Chosen**: Clear relation association, supports multiple polymorphic relations per model
+- **Alternative**: Simpler but limits to one polymorphic relation per model
+
+### ID Storage Type
+**Options**:
+1. TEXT columns for polymorphic IDs (Chosen - per spec)
+2. Separate typed columns per target model
+3. JSONB column with structured data
+
+**Trade-offs**:
+- **Chosen**: Flexible, spec-compliant, no schema coupling
+- **Alternatives**: Type safety vs. flexibility trade-off
+
+### Junction Table Strategy  
+**Options**:
+1. Dedicated polymorphic junction tables (Chosen)
+2. Single polymorphic relations table
+3. Hybrid approach with table-per-relation-type
+
+**Trade-offs**:
+- **Chosen**: Clear separation, follows existing ForMany pattern
+- **Single table**: Centralized but harder to query efficiently
+- **Hybrid**: Complex implementation, unclear benefits
+
+### Migration Strategy
+**Options**:
+1. Additive-only changes (Chosen)
+2. Schema versioning with migrations
+3. Breaking changes with major version bump
+
+**Trade-offs**:
+- **Chosen**: Backward compatible, safe for existing systems
+- **Versioning**: More complex but enables schema evolution
+- **Breaking**: Simpler implementation but adoption barrier
+
+## 4. Active Working Log
+
+| Task | Status | Commit/PR | Notes |
+|------|--------|-----------|-------|
+| **Task 1** Complete morphe-go Polymorphism | Done | morphe-go batched | **SYNCED**: All morphe-go changes complete and synced |
+| **Task 2** ForOnePoly Column Generation | Done | ✅ | **COMPLETE**: ForOnePoly columns generated correctly |
+| **Task 3** ForManyPoly Junction Tables | Done | ✅ | **COMPLETE**: Polymorphic junction tables with proper constraints |
+| **Task 4** HasOnePoly/HasManyPoly Relations | Done | ✅ | **COMPLETE**: Inverse polymorphic relationships with through validation |
+| **Task 5** Polymorphic Validation | Done | ✅ | **COMPLETE**: Comprehensive validation with clear error messages |
+| **Task 6** Integration Testing | Done | ✅ | **MODEL-LEVEL COMPLETE**: ForOnePoly + ForManyPoly integration tests passing |
+| **Task 7** Entity-Level Polymorphic Views | Done | ✅ | **COMPLETE**: Entity views correctly handle polymorphic relationships |
+| **Task 8** Entity-Level Integration Testing | Done | ✅ | **COMPLETE**: Comprehensive entity-level polymorphic testing |
+
+## 5. Status Updates
+
+### 2025-06-23 - Initial Analysis Completed
+- Analyzed existing codebase architecture
+- Identified gap between current implementation and polymorphism spec
+- Created comprehensive implementation plan with 6 focused tasks
+- Established TDD workflow with human review checkpoints
+
+### 2025-06-23 - Cross-Repository Dependency Identified
+- **Critical Discovery**: yamlops package is in separate `morphe-go` repository
+- Updated implementation plan to reflect cross-repo dependencies
+- Task 1 requires changes to `morphe-go/pkg/yamlops/relation.go` + manual dependency sync
+- All polymorphic detection functions must be implemented in external dependency first
+
+### 2025-06-23 - Task 1 Progress: Complete morphe-go Polymorphism Support
+- ✅ **Sub-task 1.1**: Polymorphic relation detection functions (yamlops)
+  - RED-GREEN-REFACTOR cycle complete with testify assertions
+  - 5 compositional functions: `IsRelationPoly`, `IsRelationPolyFor`, `IsRelationPolyHas`, `IsRelationPolyOne`, `IsRelationPolyMany`
+  - All tests pass: 9/9 test functions in yamlops package
+- ✅ **Sub-task 1.2**: ModelRelation structure extensions (`for`, `through` fields)
+- ✅ **Sub-task 1.3**: EntityRelation validation updates (add polymorphic types)
+- ✅ **Sub-task 1.4**: Model/Entity polymorphic validation logic
+- ✅ **Sub-task 1.5**: Deep clone method updates
+- ✅ **Sub-task 1.6**: Comprehensive morphe-go testing
+- ✅ **BATCHED APPROACH**: All morphe-go changes complete, ready for single dependency sync
+
+### 2025-06-23 - Task 1 COMPLETE: All morphe-go Polymorphism Support
+- ✅ **All Sub-tasks Complete**: Successfully implemented comprehensive polymorphic support in morphe-go
+- 🔧 **Data Structures**: Extended ModelRelation and EntityRelation with `for` and `through` fields
+- 🛡️ **Validation**: Added polymorphic type validation with proper error handling for missing properties
+- 🧪 **Testing**: All existing tests pass + new polymorphic tests added and passing
+- 📦 **Batched Changes**: Single comprehensive update prevents multiple dependency syncs
+- ✅ **SYNCED**: Complete morphe-go implementation synced to plugin-morphe-psql-types
+
+### 2025-06-23 - Task 2 COMPLETE: ForOnePoly Column Generation
+- ✅ **TDD RED-GREEN-REFACTOR**: Followed proper TDD cycle with failing test → implementation → refactor
+- 🏗️ **Column Generation**: Successfully generates `{relation_name}_type` and `{relation_name}_id` TEXT columns
+- 🚫 **No Foreign Keys**: Correctly skips foreign key constraint generation for polymorphic relationships
+- 🐍 **Naming Conventions**: Proper snake_case column naming from camelCase relation names
+- 🧪 **Test Coverage**: Two comprehensive tests covering basic and edge cases (long relation names)
+- 🔧 **Clean Implementation**: Added polymorphic logic without breaking existing functionality
+
+### 2025-06-23 - Task 3 COMPLETE: ForManyPoly Junction Tables
+- ✅ **TDD RED-GREEN-REFACTOR**: Followed proper TDD cycle with failing test → implementation → refactor
+- 🔍 **Root Cause Analysis**: Identified that ForManyPoly was incorrectly matching regular ForMany pattern
+- 🛠️ **Fix Applied**: Added `!yamlops.IsRelationPoly()` check to exclude polymorphic relations from regular ForMany processing
+- 🏗️ **Junction Tables**: Successfully generates polymorphic junction tables with type + id columns
+- 🔐 **Proper Constraints**: Unique constraints on (source_id, target_type, target_id) with no foreign key constraints on polymorphic columns
+- 🧪 **Test Coverage**: Comprehensive test covering junction table structure, columns, constraints, and foreign keys
+- 🔧 **Clean Implementation**: Added polymorphic junction table logic without breaking existing functionality
+
+### 2025-06-23 - Task 4 COMPLETE: HasOnePoly/HasManyPoly Inverse Relations
+- ✅ **TDD RED-GREEN-REFACTOR**: Followed proper TDD cycle with failing validation tests → implementation → passing tests
+- 🔍 **No Additional Columns**: HasOnePoly/HasManyPoly relationships correctly don't generate database columns (rely on forward relations)
+- 🛡️ **Through Validation**: Added cross-model validation that ensures `through` property references valid polymorphic relations
+- 🏗️ **Registry-Based Lookup**: Implemented proper validation that searches across all models in registry for through relationships
+- 🐛 **Initial Bug Fix**: Fixed validation logic that was incorrectly looking for through relations only in same model
+- 🧪 **Test Coverage**: Added comprehensive tests for both valid scenarios and error cases (invalid through properties)
+- 🔧 **Clean Implementation**: Added validation without breaking existing functionality, all existing tests continue to pass
+
+### 2025-06-23 - Task 5 COMPLETE: Polymorphic Validation & Error Handling
+- ✅ **TDD RED-GREEN-REFACTOR**: Followed proper TDD cycle with comprehensive failing validation tests → implementation → all tests passing
+- 🔍 **For Property Validation**: Validates that all models referenced in `for` property exist in the registry
+- 🛡️ **Missing Property Detection**: Clear error messages for missing `for` properties in ForOnePoly/ForManyPoly relationships
+- 🚫 **Empty Array Validation**: Detects and reports when `for` property is empty (must have at least one target model)
+- 🔄 **Circular Reference Detection**: Implemented DFS-based cycle detection to prevent circular polymorphic references
+- 🏗️ **Registry Integration**: All validation logic properly integrates with the registry for cross-model validation
+- 🧪 **Comprehensive Test Coverage**: Added 7 new validation tests covering all edge cases and error scenarios
+- 🐛 **Test Fix**: Fixed existing LongRelationName test that was missing required model in registry
+- 🔧 **Enhanced Error Messages**: All validation errors provide clear, actionable error messages for developers
+- 🎯 **Detailed Circular Reference Detection**: Shows full cycle path and actionable guidance for resolving circular polymorphic references
+
+### 2025-06-23 - Task 6 Progress: Model-Level Integration Testing Complete
+- ✅ **ForOnePoly Integration**: Added Comment model with polymorphic relationship to Person and Company
+- ✅ **ForManyPoly Integration**: Added Tag model with polymorphic many-to-many relationship via junction table  
+- ✅ **HasOnePoly/HasManyPoly Integration**: Added inverse polymorphic relationships to Person and Company models
+- 🔧 **Junction Table Discovery**: Identified actual naming pattern is `tag_taggables.sql` (not `tags_taggable.sql`)
+- 📊 **Comprehensive Testing**: Integration test now covers all polymorphic relationship types at model level
+- 🏗️ **Database Schema**: Generated SQL correctly includes polymorphic columns, junction tables, and proper constraints
+- ✅ **Integration Tests Passing**: All model-level polymorphic functionality verified through end-to-end testing
+
+### 2025-06-23 - New Tasks Added: Entity-Level Polymorphism Support
+- 📋 **Task 7 Added**: Entity-Level Polymorphic View Generation with clear acceptance criteria
+- 📋 **Task 8 Added**: Entity-Level Integration Testing for comprehensive polymorphic entity coverage
+- 🎯 **Entity Strategy Defined**: Simple approach including raw polymorphic columns in entity views
+- 🔄 **Next Phase**: Ready to implement entity-level polymorphic support following established patterns
+
+---
+
+## Polymorphism Specification Reference
+
+### Supported Polymorphic Relation Types
+
+* **ForOnePoly**: Polymorphic "belongs to" relationship - current model belongs to one instance of multiple possible model types
+  * Implementation: Single polymorphic reference columns on model table
+  * Example: Comment ForOnePoly Commentable (Post, Article, Video)
+
+* **ForManyPoly**: Polymorphic "many-to-many" relationship via junction table  
+  * Implementation: Junction table with polymorphic columns
+  * Example: Tag ForManyPoly Taggable (Post, Product, User)
+
+* **HasOnePoly**: Inverse of ForOnePoly - current model can have one model of different types referring to it
+  * Implementation: Configured via `through` property, no additional columns
+  * Example: Post HasOnePoly Comment (through Commentable)
+
+* **HasManyPoly**: Inverse of ForManyPoly - current model can have multiple models of different types referring to it
+  * Implementation: Configured via `through` property, no additional columns  
+  * Example: Post HasManyPoly Tag (through Taggable)
+
+### Configuration Format
+
+```yaml
+# ForOnePoly - Comment can belong to Post, Article, or Video
+related:
+  Commentable:
+    type: ForOnePoly
+    for:
+      - Post
+      - Article  
+      - Video
+
+# HasOnePoly - Post can have Comments referring to it
+related:
+  Comment:
+    type: HasOnePoly
+    through: Commentable
+```
+
+### Database Implementation
+
+- **Polymorphic IDs**: Stored as TEXT, round-tripped as strings
+- **Type Field**: Indicates which model type the relationship targets
+- **No Foreign Keys**: Polymorphic nature prevents traditional FK constraints
+- **Unique Constraints**: Applied to prevent duplicate polymorphic relationships
+
+### Polymorphic Aliasing Support
+
+As of 2025-01-15, polymorphic relationships fully support aliasing through the general aliasing feature:
+- **ForOnePoly/ForManyPoly**: Can use `aliased` property to reference different target models
+- **HasOnePoly/HasManyPoly**: Support the advanced pattern with `through` + `aliased` for semantic field naming
+- See `aliasing.md` for complete aliasing documentation and the polymorphic inverse aliasing pattern 

--- a/testdata/ground-truth/aliasing/models/contacts.sql
+++ b/testdata/ground-truth/aliasing/models/contacts.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS public.contacts (
+    id SERIAL PRIMARY KEY,
+    email TEXT NOT NULL,
+    phone TEXT NOT NULL,
+    address TEXT NOT NULL
+);

--- a/testdata/ground-truth/aliasing/models/people.sql
+++ b/testdata/ground-truth/aliasing/models/people.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS public.people (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL,
+    personal_contact_id INTEGER NOT NULL,
+    work_contact_id INTEGER NOT NULL
+);
+
+ALTER TABLE public.people
+    ADD CONSTRAINT fk_people_personal_contact_id FOREIGN KEY (personal_contact_id) REFERENCES public.contacts(id) ON DELETE CASCADE,
+    ADD CONSTRAINT fk_people_work_contact_id FOREIGN KEY (work_contact_id) REFERENCES public.contacts(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_people_personal_contact_id ON public.people (personal_contact_id);
+CREATE INDEX IF NOT EXISTS idx_people_work_contact_id ON public.people (work_contact_id);

--- a/testdata/registry/aliasing/models/Contact.morphe.yaml
+++ b/testdata/registry/aliasing/models/Contact.morphe.yaml
@@ -1,0 +1,21 @@
+name: Contact
+fields:
+  ID:
+    type: AutoIncrement
+  Email:
+    type: String
+  Phone:
+    type: String
+  Address:
+    type: String
+identifiers:
+  primary:
+    fields:
+      - ID
+related:
+  PersonsAsWork:
+    type: HasMany
+    aliased: Person.WorkContact
+  PersonsAsPersonal:
+    type: HasMany
+    aliased: Person.PersonalContact

--- a/testdata/registry/aliasing/models/Person.morphe.yaml
+++ b/testdata/registry/aliasing/models/Person.morphe.yaml
@@ -1,0 +1,25 @@
+name: Person
+fields:
+  ID:
+    type: AutoIncrement
+  Name:
+    type: String
+  Email:
+    type: String
+identifiers:
+  primary:
+    fields:
+      - ID
+related:
+  WorkContact:
+    type: ForOne
+    aliased: Contact
+  PersonalContact:
+    type: ForOne
+    aliased: Contact
+  WorkProjects:
+    type: ForMany
+    aliased: Project
+  PersonalProjects:
+    type: ForMany
+    aliased: Project

--- a/testdata/registry/aliasing/models/Project.morphe.yaml
+++ b/testdata/registry/aliasing/models/Project.morphe.yaml
@@ -1,0 +1,21 @@
+name: Project
+fields:
+  ID:
+    type: AutoIncrement
+  Title:
+    type: String
+  Description:
+    type: String
+  Status:
+    type: String
+identifiers:
+  primary:
+    fields:
+      - ID
+related:
+  WorkMembers:
+    type: HasMany
+    aliased: Person.WorkProjects
+  PersonalMembers:
+    type: HasMany
+    aliased: Person.PersonalProjects


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements alias-aware model/entity compilation (columns, FKs, junctions, joins) with early validation, expanded tests/docs, and updated morphe-go dependency.
> 
> - **Aliasing Support**:
>   - Resolve aliased targets via `yamlops.GetRelationTargetName()` in `pkg/compile/compile_models.go` and `pkg/compile/compile_entities.go` while preserving relation-based naming for columns/tables.
>   - Add `validateAliasedRelations()` to fail early when aliased targets are missing.
>   - Update entity traversal/join logic to track source model, sort joins, and use aliased targets for PK lookups.
> - **Polymorphism**:
>   - Ensure aliasing works with `ForOnePoly`/`ForManyPoly` and inverse `Has*Poly` paths in both models and entities (no unintended materialization).
> - **Tests & Fixtures**:
>   - Add extensive tests for aliased `ForOne`/`ForMany`, polymorphic aliasing, join generation with differing PKs, and error cases.
>   - Add `testdata/registry/aliasing/...` and ground-truth SQL for aliasing.
> - **Docs**:
>   - New guides: `aliasing.md`, `ALIASING_INTEGRATION_SUMMARY.md`, `MORPHE-GO.md`, `polymorphism.md`.
> - **Deps**:
>   - Bump `github.com/kalo-build/morphe-go` to `v0.0.0-20251016080731-9aae9ab2af3e`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f4da714a210947ca4e53819c74beafbeee7663a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->